### PR TITLE
added missing PG_FUNCTION_INFO_V1 for table_log_basic()

### DIFF
--- a/table_log.c
+++ b/table_log.c
@@ -260,6 +260,7 @@ static void getRelationPrimaryKeyColumns(TableLogRestoreDescr *restore_descr);
 /* this is a V1 (new) function */
 /* the trigger function */
 PG_FUNCTION_INFO_V1(table_log);
+PG_FUNCTION_INFO_V1(table_log_basic);
 PG_FUNCTION_INFO_V1(table_log_forward);
 /* build only, if the 'Table Function API' is available */
 #ifdef FUNCAPI_H_not_implemented


### PR DESCRIPTION
CREATE or UPGRADE EXTENSION fails in PostgreSQL 10 with
  could not find function information for function "table_log_basic"